### PR TITLE
Add BitsyLLVM to the list of implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ If you're attending either, be sure to say hello!
 * [BitsySwift](https://github.com/apbendi/bitsy-swift) - A Bitsy compiler written in Swift; the first-and-canonical implementation of Bitsy.
 * [Bitsy.NET](https://github.com/wessupermare/Bitsy.NET) - Bitsy implementations in C# and Visual Basic.
 * [xbitsy](https://github.com/apbendi/xbitsy) - A Bitsy interpreter written in Elixir.
+* [BitsyLLVM](https://github.com/SimplyDanny/bitsy-llvm) - A Bitsy compiler based on the [LLVM](https://llvm.org) compiler infrastructure.
 
 Open a pull request to add your implementation to the list!
 


### PR DESCRIPTION
I have come up with an implementation of Bitsy based on the LLVM compiler infrastructure and would like to add it to your list as you have requested.

All reference tests run fine, so it seems to be quite complete.

Feel free to check it out and to give feedback. I would appreciate any suggestions for improvement.